### PR TITLE
fix transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.4",
-    "basehub": "^9.0.4",
+    "basehub": "^9.0.6",
     "ts-loader": "^9.4.2",
     "typescript": "^5.0.4",
     "xmcp": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.11.4
         version: 1.12.3
       basehub:
-        specifier: ^9.0.4
-        version: 9.0.4(@babel/runtime@7.27.6)(react@18.3.1)(typescript@5.8.3)
+        specifier: ^9.0.6
+        version: 9.0.6(@babel/runtime@7.27.6)(react@18.3.1)(typescript@5.8.3)
       ts-loader:
         specifier: ^9.4.2
         version: 9.5.2(typescript@5.8.3)(webpack@5.99.9(@swc/core@1.12.1))
@@ -1006,8 +1006,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  basehub@9.0.4:
-    resolution: {integrity: sha512-8ZZU+HM7aVknlB3Z9trxt6afkDmWqC7UR2ZFlxVAl9F+Ue8fxmBJ4STSFKC80SNoAhN6svxVk9gmhYQNOGUqjA==}
+  basehub@9.0.6:
+    resolution: {integrity: sha512-ALJg8whF9mS2juQwB6buDLweknzYHxqg68kqTnUt3AzDphHGvJ9i/IS9sfYN+c+GFTg4/NY01qYPgo9ZmI175A==}
     hasBin: true
 
   binary-extensions@2.3.0:
@@ -3766,7 +3766,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  basehub@9.0.4(@babel/runtime@7.27.6)(react@18.3.1)(typescript@5.8.3):
+  basehub@9.0.6(@babel/runtime@7.27.6)(react@18.3.1)(typescript@5.8.3):
     dependencies:
       '@basehub/mutation-api-helpers': 2.0.11
       '@radix-ui/react-slot': 1.2.3(react@18.3.1)


### PR DESCRIPTION
bh SDK `9.0.4` was throwing errors when using the create block tool (transaction error)

updated to `9.0.6` seems to fix it

9.0.4
![Screenshot 2025-06-20 at 11 15 23 AM](https://github.com/user-attachments/assets/fae9b294-ca14-4be0-86ce-36a9b83f576c)

9.0.6
![Screenshot 2025-06-20 at 11 16 42 AM](https://github.com/user-attachments/assets/b05d58f9-c1f6-4f48-8e2e-6bd3a067cd7d)
